### PR TITLE
Bump Grpc.Tools from 2.67.0 to 2.68.1 in the grpc group

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -86,7 +86,7 @@
     <!-- Grpc -->
     <PackageVersion Include="Grpc.AspNetCore" Version="$(GrpcVersion)" />
     <PackageVersion Include="Grpc.AspNetCore.Server.ClientFactory" Version="$(GrpcVersion)" />
-    <PackageVersion Include="Grpc.Tools" Version="2.67.0" PrivateAssets="All" />
+    <PackageVersion Include="Grpc.Tools" Version="2.68.1" PrivateAssets="All" />
     <!-- Miscellaneous -->
     <PackageVersion Include="Automapper" Version="13.0.1" />
     <PackageVersion Include="Dapper" Version="2.1.35" />

--- a/src/ClientApp/ClientApp.csproj
+++ b/src/ClientApp/ClientApp.csproj
@@ -63,7 +63,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.28.3" />
     <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.67.0">
+    <PackageReference Include="Grpc.Tools" Version="2.68.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Bumps the grpc group with 1 update: [Grpc.Tools](https://github.com/grpc/grpc).


Updates `Grpc.Tools` from 2.67.0 to 2.68.1
- [Release notes](https://github.com/grpc/grpc/releases)
- [Changelog](https://github.com/grpc/grpc/blob/master/doc/grpc_release_schedule.md)
- [Commits](https://github.com/grpc/grpc/commits)

---
updated-dependencies:
- dependency-name: Grpc.Tools dependency-type: direct:production update-type: version-update:semver-minor dependency-group: grpc ...